### PR TITLE
changes fade-in animation back to original values

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -648,8 +648,7 @@ img.egg {
 
 @keyframes fade-in {
   0% {
-    /* TODO need to set as 0 added as testing */
-    opacity: 1;
+    opacity: 0;
   }
   100% {
     opacity: 1;


### PR DESCRIPTION
the starting opacity for the fade in animation had been set to 1 during testing, was not set back. this change returns the starting opacity to 0.