### PR TITLE
sets min-width for title button container, avoiding button text wrap

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -111,6 +111,7 @@ body {
   position: absolute;
   right: 3rem;
   bottom: 2rem;
+  min-width: 18rem;
 }
 .title-screen-btn {
   background-color: Transparent;


### PR DESCRIPTION
fixes an issue where the credits button would wrap the trailing s to the next line byt adding a min width to the button wrapper div
closes #131 