### PR TITLE
adds a line that returns focus to answer field on power up 

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -398,10 +398,21 @@ const specialEffects = {
     powers.armor.image.addEventListener('click', () => {
       specialEffects.armorClicked = true;
       powers.armor.description.innerHTML = `Prevents the timer from decreasing on the next ${5 - this.armorHits} wrong answers. Currently active.`;
+      // returns focus to answer field after clicking on power
+      document.getElementById('answer').focus();
     });
-    powers.timeFreeze.image.addEventListener('click', () => specialEffects.useTimeFreeze());
-    powers.sharpClaw.image.addEventListener('click', () => specialEffects.useClaw());
-    powers.wingFoot.image.addEventListener('click', () => specialEffects.useWingFoot());
+    powers.timeFreeze.image.addEventListener('click', () => {
+      specialEffects.useTimeFreeze();
+      document.getElementById('answer').focus();
+    });
+    powers.sharpClaw.image.addEventListener('click', () => {
+      specialEffects.useClaw();
+      document.getElementById('answer').focus();
+    });
+    powers.wingFoot.image.addEventListener('click', () => {
+      specialEffects.useWingFoot();
+      document.getElementById('answer').focus();
+    });
   },
   addNewRandomPower() {
     const shuffledPowers = shuffle(Object.keys(powers));


### PR DESCRIPTION
When you click a power up, the input field loses focus. The user then has to click on the field which is not intuituve and distracting. This branch returns focus to the input field in the power use button event handler.